### PR TITLE
Having disabled="false" prevents the form being POSTed

### DIFF
--- a/plugins/sandbox-onboarding/assets/js/cap_user_ui.js
+++ b/plugins/sandbox-onboarding/assets/js/cap_user_ui.js
@@ -11,6 +11,6 @@ window.onload = (event) => {
 
   function consentClicked() {
     const button = document.getElementById('request_account');
-    cb.checked ? button.setAttribute('disabled', false) : button.setAttribute('disabled', true);
+    cb.checked ? button.removeAttribute('disabled') : button.setAttribute('disabled', true);
   }
 }


### PR DESCRIPTION
The disabled attribute has to be completely removed from the input element. Documentation on this is misleading, but the proper solution seems to be this one.

Signed-off-by: Ferenc Szekely <ferenc.szekely@suse.com>